### PR TITLE
SFBB/Bug-17: Start PlayerIDMap.playeridmap index at 0

### DIFF
--- a/sabrmetrics/sfbb/tools.py
+++ b/sabrmetrics/sfbb/tools.py
@@ -202,9 +202,9 @@ class PlayerIDMap:
             [dataframes[0].iloc[2:, 1:9].copy(), dataframes[0].iloc[2:, 10:].copy()],
             axis=1
         )
-        df.columns = pd.concat(
-            [dataframes[0].iloc[0, 1:9], dataframes[0].iloc[0, 10:]]
-        )
+        df.columns = [*dataframes[0].iloc[0, 1:9], *dataframes[0].iloc[0, 10:]]
+
+        df.reset_index(drop=True, inplace=True)
 
         return df
 

--- a/sabrmetrics/tests/test_sfbb/test_tools.py
+++ b/sabrmetrics/tests/test_sfbb/test_tools.py
@@ -74,6 +74,9 @@ class TestPlayerIDMap:
         """
         df = self.x._playeridmap_dataframe
 
+        # Check the `DataFrame` index
+        assert list(df.index) == list(range(len(df.index)))
+
         # Check that the `DataFrame` columns match the dictionary of column mappings
         assert len(df.columns) == len(self.x._playeridmap_colmap.keys())
         assert set(df.columns) == set(self.x._playeridmap_colmap.keys())


### PR DESCRIPTION
Call [`pandas.DataFrame.reset_index(drop=True, inplace=True)`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.reset_index.html) to reset the `DataFrame` index, defaulting the index to start at 0.

```python
>>> from sabrmetrics.sfbb.tools import PlayerIDMap
>>> playeridmap = PlayerIDMap()
>>> pidmap = playeridmap.playeridmap
>>> pidmap.index
RangeIndex(start=0, stop=2879, step=1)
>>> len(pidmap.index)
2879
```

[Test Report (ZIP Archive)](https://github.com/JacobLee23/SABRmetrics/files/9413154/report.zip)

Close #17 