### PR TITLE
SFBB/Bug-16: Start PlayerIDMap.changelog index at 0

### DIFF
--- a/sabrmetrics/sfbb/tools.py
+++ b/sabrmetrics/sfbb/tools.py
@@ -353,7 +353,9 @@ class PlayerIDMap:
         # - The row at index 0 is a row of the table column names.
         # - The column at index 0 is a numbering of the table rows.
         df = dataframes[0].iloc[1:, 1:].copy()
-        df.columns = dataframes[0].iloc[0, 1:]
+        df.columns = list(dataframes[0].iloc[0, 1:])
+
+        df.reset_index(drop=True, inplace=True)
 
         return df
 

--- a/sabrmetrics/tests/test_sfbb/test_tools.py
+++ b/sabrmetrics/tests/test_sfbb/test_tools.py
@@ -128,6 +128,9 @@ class TestPlayerIDMap:
         """
         df = self.x._changelog_dataframe
 
+        # Check the `DataFrame` index
+        assert list(df.index) == list(range(len(df.index)))
+
         # Check that the `DataFrame` columns match the dictionary of column mappings
         assert len(df.columns) == len(self.x._changelog_colmap.keys())
         assert set(df.columns) == set(self.x._changelog_colmap.keys())


### PR DESCRIPTION
Call [`pandas.DataFrame.reset_index(drop=True, inplace=True)`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.reset_index.html) to reset the `DataFrame` index, defaulting the index to start at 0.

```python
>>> from sabrmetrics.sfbb.tools import PlayerIDMap
>>> playeridmap = PlayerIDMap()
>>> changelog = playeridmap.changelog
>>> changelog.index
RangeIndex(start=0, stop=567, step=1)
>>> len(changelog)
567
```

[Test Report (ZIP Archive)](https://github.com/JacobLee23/SABRmetrics/files/9413535/report.zip)

Close #16 