### PR TITLE
Bug-25: Exclude sabrmetrics.tests and sabrmetrics.docs from setuptools package search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabrmetrics"
-version = "0.5.2a2"
+version = "0.5.2a3"
 description = "A web scraper for SABRmetrics websites"
 readme = "README.md"
 authors = [ { name = "Jacob Lee", email = "Jacob.J.Lee@outlook.com" } ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,9 @@ requires-python = ">=3.6"
 homepage = "https://github.com/JacobLee23/SABRmetrics"
 
 [tool.setuptools.packages.find]
-exclude = ["sabrmetrics.tests*"]
+where = ["."]
+include = ["sabrmetrics*"]
+exclude = [
+    "sabrmetrics.docs*",
+    "sabrmetrics.tests*"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,11 @@ requires-python = ">=3.6"
 
 [project.urls]
 homepage = "https://github.com/JacobLee23/SABRmetrics"
+
+[tool.setuptools.packages]
+find = {}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["sabrmetrics*"]
+exclude = ["sabrmetrics.tests*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,4 @@ requires-python = ">=3.6"
 homepage = "https://github.com/JacobLee23/SABRmetrics"
 
 [tool.setuptools.packages.find]
-where = ["."]
-include = ["sabrmetrics*"]
 exclude = ["sabrmetrics.tests*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabrmetrics"
-version = "0.5.2a3"
+version = "0.5.2a4"
 description = "A web scraper for SABRmetrics websites"
 readme = "README.md"
 authors = [ { name = "Jacob Lee", email = "Jacob.J.Lee@outlook.com" } ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabrmetrics"
-version = "0.5.1"
+version = "0.5.2a1"
 description = "A web scraper for SABRmetrics websites"
 readme = "README.md"
 authors = [ { name = "Jacob Lee", email = "Jacob.J.Lee@outlook.com" } ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabrmetrics"
-version = "0.5.2a4"
+version = "0.5.3"
 description = "A web scraper for SABRmetrics websites"
 readme = "README.md"
 authors = [ { name = "Jacob Lee", email = "Jacob.J.Lee@outlook.com" } ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabrmetrics"
-version = "0.5.2a1"
+version = "0.5.2a2"
 description = "A web scraper for SABRmetrics websites"
 readme = "README.md"
 authors = [ { name = "Jacob Lee", email = "Jacob.J.Lee@outlook.com" } ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ requires-python = ">=3.6"
 [project.urls]
 homepage = "https://github.com/JacobLee23/SABRmetrics"
 
-[tool.setuptools.packages]
-find = {}
-
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["sabrmetrics*"]


### PR DESCRIPTION
```python
>>> from sabrmetrics import tests
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'tests' from 'sabrmetrics' (C:\Users\...\AppData\Local\Programs\Python\Python310\lib\site-packages\sabrmetrics\__init__.py)
>>> from sabrmetrics import docs
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'docs' from 'sabrmetrics' (C:\Users\...\AppData\Local\Programs\Python\Python310\lib\site-packages\sabrmetrics\__init__.py)
>>> from sabrmetrics import playerids
>>> from sabrmetrics import sfbb
```

Close #25 